### PR TITLE
Adding support for ignoring files from tsindex

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function(file, opt) {
 	var fileName;
 	var contentBuilder;
 	var cwd;
+	var ignoreToken = opt.ignoreToken || "/// tsindex:ignore";
 
 	if (typeof file === 'string') {
 		fileName = file;
@@ -39,6 +40,12 @@ module.exports = function(file, opt) {
 			cb();
 			return;
 		}
+
+		if(file.contents.toString().startsWith(ignoreToken)){
+			gutil.log(`${path.basename(file.path)} is ignored from tsindex due to the presence of the token '${ignoreToken}'.`);
+			cb();
+			return;
+		}		
 		
 		var ext = path.extname(file.path);
 		var ext2 = path.extname(path.basename(file.path, ext));


### PR DESCRIPTION
Currently, this plugin exports everything. However, it can be useful ignore some files depending on the scenario. 

For example, `MyCore.ts` exports `MyCore` class, which is used by `MyProcessor` in `MyProcessor.ts`. Now consider `MyCore` to be package-scoped; i.e. it does not make sense to make `MyCore` to be a part of public API exposed by the package.

In such scenario, it suffices to simply ignore `MyCore.ts` in `index.ts`.

This PR adds a simple capability to ignore files by using a string token, which needs to be used in the source file that needs to be ignored. The token can also be overridden by user defined options (in build task).

Examples:

- Use the token in the source file, which needs to be ignored. The file content must start with the ignore token, as shown in the example below. The default token is `"/// tsindex:ignore"`.

  ```typescript
  /// tsindex:ignore
  import { stuffs } from "somepackage1"
  ...

  export class MyCore{
  ...
  }
  ``` 
- Configure it via build task:
  ```javascript
  tsProject.src()
      .pipe(tsindex(paths.src + '/index.ts',{ignoreToken:"/// my_custom_token"}))
      ...
  ```
  However, in this case, the token `/// my_custom_token` needs to be used in the source file instead.

